### PR TITLE
Avoid invalid minimization sequences. Add shutdown() method to Scheduler...

### DIFF
--- a/src/main/scala/verification/BasicScheduler.scala
+++ b/src/main/scala/verification/BasicScheduler.scala
@@ -207,4 +207,8 @@ class BasicScheduler extends Scheduler {
     throw new Exception("NYI")
   }
 
+  def shutdown() {
+    instrumenter.restart_system
+  }
+
 }

--- a/src/main/scala/verification/NullScheduler.scala
+++ b/src/main/scala/verification/NullScheduler.scala
@@ -51,5 +51,6 @@ class NullScheduler extends Scheduler {
   def enqueue_message(receiver: String, msg: Any) {
     throw new Exception("NYI")
   }
+  def shutdown() {}
 
 }

--- a/src/main/scala/verification/Scheduler.scala
+++ b/src/main/scala/verification/Scheduler.scala
@@ -35,7 +35,8 @@ trait Scheduler {
   // Tell the scheduler that it should eventually schedule the given message.
   // Used to feed messages from the external world into actor systems.
   def enqueue_message(receiver: String, msg: Any)
-  // TODO(cs): add shutdown()
+  // Shut down the actor system.
+  def shutdown()
 
 }
 

--- a/src/main/scala/verification/minification/Minimizer.scala
+++ b/src/main/scala/verification/minification/Minimizer.scala
@@ -1,5 +1,5 @@
 package akka.dispatch.verification
 
 trait Minimizer {
-  def minimize(events: List[ExternalEvent]) : List[ExternalEvent]
+  def minimize(events: Seq[ExternalEvent]) : Seq[ExternalEvent]
 }

--- a/src/main/scala/verification/minification/OneAtATime.scala
+++ b/src/main/scala/verification/minification/OneAtATime.scala
@@ -1,20 +1,41 @@
 package akka.dispatch.verification
 
 import scala.collection.mutable.ListBuffer
-
-// TODO(cs): treat failure and recovery events as atomic pairs.
+import scala.collection.mutable.HashSet
 
 class LeftToRightRemoval (oracle: TestOracle) extends Minimizer {
-  def minimize(events: List[ExternalEvent]) : List[ExternalEvent] = {
-    var chosen = ListBuffer[ExternalEvent]()
-    for ((event,idx) <- events.zipWithIndex) {
+  def minimize(events: Seq[ExternalEvent]) : Seq[ExternalEvent] = {
+    // First check if the initial trace violates the exception
+    println("Checking if unmodified trace triggers violation...")
+    if (oracle.test(events)) {
+      throw new IllegalArgumentException("Unmodified trace does not trigger violation")
+    }
+
+    var dag : EventDag = new UnmodifiedEventDag(events)
+    var events_to_test = dag.get_atomic_events
+    var tested_events = new HashSet[AtomicEvent]()
+
+    while (events_to_test.length > 0) {
       // Try removing the event
-      val passes = oracle.test(chosen ++ events.slice(idx + 1, events.length))
-      if (passes) {
-        chosen = chosen :+ event
+      val event = events_to_test(0)
+      println("Trying removal of event " + event.toString)
+      tested_events += event
+      val new_dag = dag.remove_events(List(event))
+
+      if (oracle.test(new_dag.get_all_events)) {
+        println("passes")
+        // Move on to the next event to test
+        events_to_test = events_to_test.slice(1, events_to_test.length)
+      } else {
+        println("fails. Pruning")
+        dag = new_dag
+        // The atomic events to test may have changed after removing
+        // the event we just pruned, so recompute.
+        events_to_test = dag.get_atomic_events.filterNot(e => tested_events.contains(e))
       }
     }
-    return chosen.toList
+
+    return dag.get_all_events
   }
 }
 

--- a/src/main/scala/verification/minification/TestOracle.scala
+++ b/src/main/scala/verification/minification/TestOracle.scala
@@ -4,11 +4,14 @@ package akka.dispatch.verification
 trait TestOracle {
   type Invariant = () => Boolean
 
-  // See:
-  //   http://stackoverflow.com/questions/8178602/using-scala-constructor-to-set-variable-defined-in-trait
-  var invariant: Invariant
+  def setInvariant(invariant: Invariant)
 
-  // Return whether there exists any execution containing the given external
-  // events that triggers the given invariant.
-  def test(events: Iterable[ExternalEvent]) : Boolean
+  /**
+   * Return whether there exists any execution containing the given external
+   * events that triggers the given invariant.
+   * At the end of the invocation, it is the responsibility of the TestOracle
+   * to ensure that the ActorSystem is returned to a clean initial state.
+   * Throws an IllegaleArgumentException if setInvariant has not been invoked.
+   */
+  def test(events: Seq[ExternalEvent]) : Boolean
 }

--- a/src/main/scala/verification/minification/Util.scala
+++ b/src/main/scala/verification/minification/Util.scala
@@ -1,13 +1,17 @@
 package akka.dispatch.verification
 
+import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.Map
+import scala.collection.mutable.HashSet
+
 object MinificationUtil {
-  def split_list(l: List[Any], split_ways: Int) : List[List[Any]] = {
+  def split_list(l: Seq[Any], split_ways: Int) : Seq[Seq[Any]] = {
     // Split our inputs into split_ways separate lists
     if (split_ways < 1) {
       throw new IllegalArgumentException("Split ways must be greater than 0")
     }
 
-    var splits = List[List[Any]]()
+    var splits = List[Seq[Any]]()
     var split_interval = l.length / split_ways // integer division = floor
     var remainder = l.length % split_ways // remainder is guaranteed to be less than splitways
 
@@ -30,11 +34,216 @@ object MinificationUtil {
     }
     return splits
   }
-}
 
-class EventDag() {
-  // Keep failure and recovery events together as an atomic pair.
-  def insert_atomic_inputs(events: List[ExternalEvent]) {
+  def map_from_iterable[A,B](in: Iterable[(A,B)]) : Map[A,B] = {
+     val dest = collection.mutable.Map[A,B]()
+     for (e @ (k,v) <- in) {
+       dest += e
+     }
+
+     return dest
   }
 }
 
+/**
+ * A collection of events that should be treated as an atomic unit, i.e. one
+ * should never be removed without removing the others.
+ *
+ * Example: a Failure event and its subsequent Recovery event.
+ */
+class AtomicEvent(varargs: ExternalEvent*) {
+  var events = List(varargs: _*)
+
+  override def toString() : String = {
+    return events.map(e => e.toString).mkString("-")
+  }
+
+  override def equals(other: Any) : Boolean = {
+    other match {
+      case a: AtomicEvent => return a.events == events
+      case _ => return false
+    }
+  }
+
+  override def hashCode() : Int = {
+    return events.hashCode()
+  }
+}
+
+/**
+ * An ordered collection of ExternalEvent objects. EventDags are primarily used to present
+ * a view of the underlying events with some subset of the input events pruned
+ */
+trait EventDag {
+  /**
+   * Ensure that:
+   *  - if a failure or partition is removed, its following recovery is also removed
+   *  - if a recovery is removed, its preceding failure or partition is also removed
+   *  - if a Start event is removed, all subsequent Send events destined for
+   *    that node are removed
+   */
+  def remove_events(events: Seq[AtomicEvent]) : EventDag
+
+  /**
+   * Return the union of two EventDags.
+   */
+  def union(other: EventDag) : EventDag
+
+  /**
+   * Return all ExternalEvents that can be removed.
+   */
+  def get_atomic_events() : Seq[AtomicEvent]
+
+  /**
+   * Return all ExternalEvents, with AtomicEvents expanded.
+   */
+  def get_all_events() : Seq[ExternalEvent]
+}
+
+// Internal utility methods
+object EventDag {
+  def get_atomic_events(events: Seq[ExternalEvent]) : Seq[AtomicEvent] = {
+    // TODO(cs): memoize this computation?
+    // As we iterate through events, check whether the "fingerprint" of the
+    // current recovery event matches a "fingerprint" of a preceding failure
+    // event. If so, group them together as an Atomic pair.
+    var fingerprint_2_previous_failure : Map[String, ExternalEvent] = Map()
+    var atomics = new ListBuffer[AtomicEvent]()
+
+    for (event <- events) {
+      event match {
+        case Kill(name) => {
+          fingerprint_2_previous_failure(name) = event
+        }
+        case Partition(a,b) => {
+          val key = a + "->" + b
+          fingerprint_2_previous_failure(key) = event
+        }
+        case Start(_, name) => {
+          fingerprint_2_previous_failure get name match {
+            case Some(failure) => {
+              atomics = atomics :+ new AtomicEvent(failure, event)
+              fingerprint_2_previous_failure -= name
+            }
+            case None => {
+              // A Start at the beginning of the trace
+              atomics = atomics :+ new AtomicEvent(event)
+            }
+          }
+        }
+        case UnPartition(a,b) => {
+          val key = a + "->" + b
+          fingerprint_2_previous_failure get key match {
+            case Some(partition) => {
+              atomics = atomics :+ new AtomicEvent(partition, event)
+              fingerprint_2_previous_failure -= key
+            }
+            case None => {
+              throw new RuntimeException("UnPartition without preceding Partition")
+            }
+          }
+        }
+        case _ => atomics = atomics :+ new AtomicEvent(event)
+      }
+    }
+
+    return atomics
+  }
+
+  def remove_events(to_remove: Seq[AtomicEvent], events: Seq[ExternalEvent]) : Seq[ExternalEvent] = {
+    var all_removed = Set(to_remove.map(atomic => atomic.events).flatten: _*)
+
+    // The invariant that failures and recoveries are removed atomically is
+    // already ensured by the way AtomicEvents are constructed.
+    //
+    // All that is left for us to handle is dependencies between Start and Send
+    // events.
+
+    // Collect up all remaining events.
+    var remaining : Seq[ExternalEvent] = ListBuffer()
+    // While we collect remaining events, also ensure that for all removed Start events, we
+    // remove all subsequent Sends before the next Start event.
+    // We accomplish this by tracking whether we recently passed a removed Start event
+    // as we iterate through the list.
+    val pending_starts = new HashSet[String]()
+    for (event <- events) {
+      event match {
+        case Start(_, node) => {
+          if (all_removed.contains(event)) {
+            pending_starts += node
+          } else if (pending_starts.contains(node)) {
+            // The node has started up again, so stop filtering subsequent
+            // Send events.
+            pending_starts -= node
+          }
+        }
+        case Send(node, _) => {
+          if (pending_starts.contains(node)) {
+            all_removed += event
+          }
+        }
+        case _ => None
+      }
+
+      if (!all_removed.contains(event)) {
+        remaining = remaining :+ event
+      }
+    }
+
+    return remaining
+  }
+}
+
+/**
+ * An unmodified EventDag.
+ */
+class UnmodifiedEventDag(events: Seq[ExternalEvent]) extends EventDag {
+  val event_to_idx : Map[ExternalEvent, Int] = MinificationUtil.map_from_iterable(events.zipWithIndex)
+
+  def remove_events(to_remove: Seq[AtomicEvent]) : EventDag = {
+    val remaining = EventDag.remove_events(to_remove, events)
+    return new EventDagView(this, remaining)
+  }
+
+  def union(other: EventDag) : EventDag = {
+    if (other.get_all_events.length != 0) {
+      throw new IllegalArgumentException("Unknown events")
+    }
+    return this
+  }
+
+  def get_atomic_events() : Seq[AtomicEvent] = {
+    return EventDag.get_atomic_events(events)
+  }
+
+  def get_all_events() : Seq[ExternalEvent] = {
+    return events
+  }
+}
+
+/**
+ * A subsequence of an EventDag.
+ */
+// All EventDagViews have a pointer to the original UnmodifiedEventDag, so
+// that we can compute the proper ordering of events in a union() of two distinct
+// EventDagViews.
+class EventDagView(parent: UnmodifiedEventDag, events: Seq[ExternalEvent]) extends EventDag {
+
+  def remove_events(to_remove: Seq[AtomicEvent]) : EventDag = {
+    val remaining = EventDag.remove_events(to_remove, events)
+    return new EventDagView(parent, remaining)
+  }
+
+  def union(other: EventDag) : EventDag = {
+    val union = (events ++ other.get_all_events).sortBy[Int](e => parent.event_to_idx(e))
+    return new EventDagView(parent, union)
+  }
+
+  def get_atomic_events() : Seq[AtomicEvent] = {
+    return EventDag.get_atomic_events(events)
+  }
+
+  def get_all_events() : Seq[ExternalEvent] = {
+    return events
+  }
+}

--- a/src/main/scala/verification/schedulers/AuxilaryTypes.scala
+++ b/src/main/scala/verification/schedulers/AuxilaryTypes.scala
@@ -4,7 +4,22 @@ import akka.actor.{ActorCell, ActorRef, ActorSystem, Props}
 import akka.dispatch.{Envelope}
 
 // External events used to specify a trace
-abstract class ExternalEvent
+abstract class ExternalEvent {
+  // Ensure that ExternalEvents are unique
+  val id = IDGenerator.get()
+
+  override def equals(other: Any) : Boolean = {
+    other match {
+      case o: ExternalEvent => return id == o.id
+      case _ => return false
+    }
+  }
+
+  override def hashCode : Int = {
+    return id
+  }
+}
+
 final case class Start (prop: Props, name: String) extends ExternalEvent
 final case class Kill (name: String) extends ExternalEvent {}
 final case class Send (name: String, message: Any) extends ExternalEvent

--- a/src/main/scala/verification/schedulers/DPOR.scala
+++ b/src/main/scala/verification/schedulers/DPOR.scala
@@ -696,4 +696,9 @@ class DPOR extends Scheduler with LazyLogging {
   private[this] def enqueue_message(actor: ActorRef, msg: Any) {
     messagesToSend += ((actor, msg))
   }
+
+  def shutdown() {
+    instrumenter().restart_system
+    // TODO(cs): not thread-safe? see PeekScheduler's shutdown()
+  }
 }

--- a/src/main/scala/verification/schedulers/FairScheduler.scala
+++ b/src/main/scala/verification/schedulers/FairScheduler.scala
@@ -125,4 +125,8 @@ class FairScheduler extends Scheduler {
   def enqueue_message(receiver: String, msg: Any) {
     throw new Exception("NYI")
   }
+
+  def shutdown() {
+    instrumenter.restart_system
+  }
 }


### PR DESCRIPTION
... trait.

Ensure that:
- if a failure or partition is removed, its following recovery is also removed
- if a recovery is removed, its preceding failure or partition is also removed
- if a Start event is removed, all subsequent Send events destined for that node are removed