### PR TITLE
Implement RandomScheduler. Involves major refactoring.

### DIFF
--- a/src/main/scala/verification/minification/TestOracle.scala
+++ b/src/main/scala/verification/minification/TestOracle.scala
@@ -13,6 +13,8 @@ trait TestOracle {
    * to ensure that the ActorSystem is returned to a clean initial state.
    * Throws an IllegaleArgumentException if setInvariant has not been invoked.
    */
+  // TODO(cs): should probably ensure that WaitQuiescence events aren't ever
+  // pruned.
   def test(events: Seq[ExternalEvent]) : Boolean
 }
 

--- a/src/main/scala/verification/schedulers/AbstractScheduler.scala
+++ b/src/main/scala/verification/schedulers/AbstractScheduler.scala
@@ -1,0 +1,85 @@
+package akka.dispatch.verification
+
+import akka.actor.{ActorCell, ActorRef}
+
+import akka.dispatch.Envelope
+
+import scala.collection.mutable.Queue
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.HashSet
+
+// Basically just keeps track of actor names.
+//
+// Subclasses need to at least implement:
+//   - schedule_new_message
+//   - enqueue_message
+//   - event_produced(cell: ActorCell, envelope: Envelope)
+abstract class AbstractScheduler extends Scheduler {
+  
+  var instrumenter = Instrumenter()
+  var currentTime = 0
+  
+
+  var actorNames = new HashSet[String]
+  
+  
+  // Is this message a system message
+  def isSystemCommunication(sender: ActorRef, receiver: ActorRef): Boolean = {
+    if (sender == null && receiver == null) return true
+    val senderPath = if (sender != null) sender.path.name else "deadLetters"
+    val receiverPath = if (receiver != null) receiver.path.name else "deadLetters"
+    return isSystemMessage(senderPath, receiverPath)
+  }
+
+  def isSystemMessage(src: String, dst: String): Boolean = {
+    if ((actorNames contains src) || (actorNames contains dst))
+      return false
+    
+    return true
+  }
+
+  // Notification that the system has been reset
+  def start_trace() : Unit = {
+  }
+  
+
+  // Record that an event was consumed
+  def event_consumed(event: Event) = {
+  }
+  
+  def event_consumed(cell: ActorCell, envelope: Envelope) = {
+  }
+  
+  // Record that an event was produced 
+  def event_produced(event: Event) = {
+    event match {
+      case event : SpawnEvent => 
+        if (!(actorNames contains event.name)) {
+          println("Sched knows about actor " + event.name)
+          actorNames += event.name
+        }
+    }
+  }
+  
+  
+  // Called before we start processing a newly received event
+  def before_receive(cell: ActorCell) {
+    currentTime += 1
+  }
+  
+  // Called after receive is done being processed 
+  def after_receive(cell: ActorCell) {
+  }
+  
+  def notify_quiescence () {
+  }
+
+  def shutdown() {
+    instrumenter.restart_system
+  }
+
+  // Get next event
+  def next_event() : Event = {
+    throw new Exception("NYI")
+  }
+}

--- a/src/main/scala/verification/schedulers/DPOR.scala
+++ b/src/main/scala/verification/schedulers/DPOR.scala
@@ -110,7 +110,7 @@ class DPOR extends Scheduler with LazyLogging {
   var parentEvent = getRootEvent
 
   // Handler for FailureDetector messages
-  val fd = new FDMessageOrchestrator(this)
+  val fd = new FDMessageOrchestrator(enqueue_message)
 
   // A set of external messages to send. Messages sent between actors are not
   // queued here.

--- a/src/main/scala/verification/schedulers/EventOrchestrator.scala
+++ b/src/main/scala/verification/schedulers/EventOrchestrator.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * Additionally records which events occured during the execution, possibly including internal events.
  *
- * Generic E specifies the type of event trace. Usually either Event or
+ * Generic E specifies the type of given trace. Usually either Event or
  * ExternalEvent.
  */
 class EventOrchestrator[E] {
@@ -109,11 +109,17 @@ class EventOrchestrator[E] {
   // TODO(cs): to be implemented later: actually kill the node so that its state is cleared?
   def isolate_node (node: String) {
     inaccessible += node
+    if (fd != null) {
+      fd.isolate_node(node)
+    }
   }
 
   // Mark a node as reachable, also used to start a node
   def unisolate_node (actor: String) {
     inaccessible -= actor
+    if (fd != null) {
+      fd.unisolate_node(actor)
+    }
   }
 
   def trigger_start (name: String) = {

--- a/src/main/scala/verification/schedulers/ExternalEventInjector.scala
+++ b/src/main/scala/verification/schedulers/ExternalEventInjector.scala
@@ -1,0 +1,262 @@
+package akka.dispatch.verification
+
+import com.typesafe.config.ConfigFactory
+import akka.actor.{Actor, ActorCell, ActorRef, ActorSystem, Props}
+
+import akka.dispatch.Envelope
+
+import scala.collection.mutable.Queue
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.SynchronizedQueue
+import scala.collection.immutable.Set
+import scala.collection.mutable.HashSet
+
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
+
+abstract class MessageType()
+final case class ExternalMessage() extends MessageType
+final case class InternalMessage() extends MessageType
+final case class SystemMessage() extends MessageType
+
+// Provides O(1) lookup, but allows multiple distinct elements
+class MultiSet[E] {
+  var m = new HashMap[E, List[E]]
+
+  def add(e: E) = {
+    if (m.contains(e)) {
+      m(e) = e :: m(e)
+    } else {
+      m(e) = List(e)
+    }
+  }
+
+  def contains(e: E) : Boolean = {
+    return m.contains(e)
+  }
+
+  def remove(e: E) = {
+    if (!m.contains(e)) {
+      throw new IllegalArgumentException("No such element " + e)
+    }
+    m(e) = m(e).tail
+    if (m(e).isEmpty) {
+      m -= e
+    }
+  }
+}
+
+/**
+ * A mix-in for schedulers that take external events as input, and generate
+ * executions containing both external and internal events as output.
+ */
+trait ExternalEventInjector {
+
+  var event_orchestrator = new EventOrchestrator[ExternalEvent]()
+
+  // Handler for FailureDetector messages
+  var fd = new FDMessageOrchestrator(enqueue_message)
+  event_orchestrator.set_failure_detector(fd)
+
+  // Semaphore to wait for trace replay to be done. We initialize the
+  // semaphore to 0 rather than 1, so that the main thread blocks upon
+  // invoking acquire() until another thread release()'s it.
+  var traceSem = new Semaphore(0)
+
+  // Are we currently injecting external events or is someone using
+  // this scheduler in some strange way.
+  val currentlyInjecting = new AtomicBoolean(false)
+
+  // Semaphore to use when shutting down the scheduler. We initialize the
+  // semaphore to 0 rather than 1, so that the main thread blocks upon
+  // invoking acquire() until another thread release()'s it.
+  var shutdownSem = new Semaphore(0)
+
+  // A set of external messages to send. Messages sent between actors are not
+  // queued here.
+  var messagesToSend = new SynchronizedQueue[(ActorRef, Any)]()
+
+  // Are we expecting message receives
+  val started = new AtomicBoolean(false)
+
+  // Ensure that only one thread is running inside the scheduler when we are
+  // dispatching external messages to actors. (Does not guard the scheduler's instance
+  // variables.)
+  var schedSemaphore = new Semaphore(1)
+
+  // If we enqueued an external message, keep track of it, so that we can
+  // later identify it as an external message when it is plumbed through
+  // event_produced
+  val enqueuedExternalMessages = new MultiSet[Any]
+
+  // Enqueue an external message for future delivery
+  def enqueue_message(receiver: String, msg: Any) {
+    if (event_orchestrator.actorToActorRef contains receiver) {
+      enqueue_message(event_orchestrator.actorToActorRef(receiver), msg)
+    } else {
+      throw new IllegalArgumentException("Unknown receiver " + receiver)
+    }
+  }
+
+  def enqueue_message(actor: ActorRef, msg: Any) {
+    enqueuedExternalMessages.add(msg)
+    messagesToSend += ((actor, msg))
+  }
+
+  // Initiates message sends for all messages in messagesToSend. Note that
+  // delivery does not occur immediately! These messages will subsequently show
+  // up in event_produced as messages to be scheduled by schedule_new_message.
+  def enqueue_external_messages() {
+    // Ensure that only one thread is accessing shared scheduler structures
+    schedSemaphore.acquire
+    assert(started.get)
+
+    // Send all pending fd responses
+    fd.send_all_pending_responses()
+    // Drain message queue
+    for ((receiver, msg) <- messagesToSend) {
+      receiver ! msg
+    }
+    messagesToSend.clear()
+
+    // Wait to make sure all messages are enqueued
+    Instrumenter().await_enqueue()
+
+    // schedule_new_message is reenterant, hence release before calling.
+    schedSemaphore.release
+  }
+
+  // Given an external event trace, see the events produced
+  def execute_trace (_trace: Seq[ExternalEvent]) : Queue[Event]  = {
+    event_orchestrator.set_trace(_trace)
+    fd.startFD(Instrumenter().actorSystem)
+    // We begin by starting all actors at the beginning of time, just mark them as
+    // isolated (i.e., unreachable). Later, when we replay the `Start` event,
+    // we unisolate the actor.
+    for (t <- event_orchestrator.trace) {
+      t match {
+        case Start (prop, name) => 
+          // Just start and isolate all actors we might eventually care about [top-level actors]
+          Instrumenter().actorSystem.actorOf(prop, name)
+          event_orchestrator.isolate_node(name)
+        case _ =>
+          None
+      }
+    }
+    currentlyInjecting.set(true)
+    // Start playing back trace
+    advanceTrace()
+    // Have this thread wait until the trace is down. This allows us to safely notify
+    // the caller.
+    traceSem.acquire
+    currentlyInjecting.set(false)
+    return event_orchestrator.events
+  }
+
+  // Advance the trace
+  def advanceTrace() {
+    // Make sure the actual scheduler makes no progress until we have injected all
+    // events.
+    schedSemaphore.acquire
+    started.set(true)
+    event_orchestrator.inject_until_quiescence(enqueue_message)
+    schedSemaphore.release
+    // Since this is always called during quiescence, once we have processed all
+    // events, let us start dispatching
+    Instrumenter().start_dispatch()
+  }
+
+  /**
+   * Return `Internal` object if the event is an internal event,
+   * `External` if the event is an externally triggered messages destined
+   * towards an actor, else `System` if it is not destined towards an actor.
+   */
+  def handle_event_produced(snd: String, rcv: String, envelope: Envelope) : MessageType = {
+    event_orchestrator.events += MsgSend(snd, rcv, envelope.message)
+    // Intercept any messages sent towards the failure detector
+    if (rcv == FailureDetector.fdName) {
+      fd.handle_fd_message(envelope.message, snd)
+      return SystemMessage()
+    } else if (enqueuedExternalMessages.contains(envelope.message)) {
+      return ExternalMessage()
+    } else {
+      return InternalMessage()
+    }
+  }
+
+  def crosses_partition(snd: String, rcv: String) : Boolean = {
+    return event_orchestrator.crosses_partition(snd, rcv)
+  }
+
+  def handle_spawn_produced(event: Event) {
+    event match {
+      case event : SpawnEvent =>
+        event_orchestrator.handle_spawn_produced(event)
+    }
+  }
+
+  def handle_spawn_consumed(event: Event) {
+    val spawn_event = event.asInstanceOf[SpawnEvent]
+    event_orchestrator.handle_spawn_consumed(spawn_event)
+  }
+
+  def handle_event_consumed(cell: ActorCell, envelope: Envelope) = {
+    val snd = envelope.sender.path.name
+    val rcv = cell.self.path.name
+    val msg = envelope.message
+    if (enqueuedExternalMessages.contains(msg)) {
+      enqueuedExternalMessages.remove(msg)
+    }
+    assert(started.get)
+    event_orchestrator.events += ChangeContext(cell.self.path.name)
+    event_orchestrator.events += MsgEvent(snd, rcv, msg)
+  }
+
+  def handle_quiescence () {
+    assert(started.get)
+    started.set(false)
+    event_orchestrator.events += Quiescence
+    if (!event_orchestrator.trace_finished) {
+      // If waiting for quiescence.
+      advanceTrace()
+    } else {
+      if (currentlyInjecting.get) {
+        // Tell the calling thread we are done
+        traceSem.release
+      } else {
+        throw new RuntimeException("exploring.get returned false")
+      }
+    }
+  }
+
+  def handle_shutdown () {
+    Instrumenter().restart_system
+    shutdownSem.acquire
+  }
+
+  def handle_start_trace () {
+    shutdownSem.release
+  }
+
+  def handle_after_receive (cell: ActorCell) : Unit = {
+    event_orchestrator.events += ChangeContext("scheduler")
+  }
+
+  /**
+   * Reset ourselves and the Instrumenter to a initial clean state.
+   */
+  def reset_state () = {
+    println("resetting state...")
+    handle_shutdown()
+    event_orchestrator = new EventOrchestrator[ExternalEvent]()
+    fd = new FDMessageOrchestrator(enqueue_message)
+    event_orchestrator.set_failure_detector(fd)
+    traceSem = new Semaphore(0)
+    currentlyInjecting.set(false)
+    shutdownSem = new Semaphore(0)
+    messagesToSend = new SynchronizedQueue[(ActorRef, Any)]()
+    started.set(false)
+    schedSemaphore = new Semaphore(1)
+    println("state reset.")
+  }
+}

--- a/src/main/scala/verification/schedulers/FairScheduler.scala
+++ b/src/main/scala/verification/schedulers/FairScheduler.scala
@@ -11,44 +11,35 @@ import scala.collection.mutable.HashSet
 /**
  * Schedules events in a round-robin fashion.
  */
-class FairScheduler extends Scheduler {
-  
-  var instrumenter = Instrumenter()
-  var currentTime = 0
+class FairScheduler extends AbstractScheduler {
+  var actorQueue = new Queue[String]
   var index = 0
-  
+
   // Current set of enabled events.
   val pendingEvents = new HashMap[String, Queue[(ActorCell, Envelope)]]  
 
-  val actorNames = new HashSet[String]
-  val actorQueue = new Queue[String]
-  
-  
-  // Is this message a system message
-  def isSystemCommunication(sender: ActorRef, receiver: ActorRef): Boolean = {
-    if (sender == null && receiver == null) return true
-    val senderPath = if (sender != null) sender.path.name else "deadLetters"
-    val receiverPath = if (receiver != null) receiver.path.name else "deadLetters"
-    return isSystemMessage(senderPath, receiverPath)
+  def event_produced(cell: ActorCell, envelope: Envelope) = {
+    val snd = envelope.sender.path.name
+    val rcv = cell.self.path.name
+    val msgs = pendingEvents.getOrElse(rcv, new Queue[(ActorCell, Envelope)])
+    
+    pendingEvents(rcv) = msgs += ((cell, envelope))
+    // Start dispatching events
+    if (!instrumenter.started.get) {
+      instrumenter.start_dispatch()
+    }
   }
 
-  def isSystemMessage(src: String, dst: String): Boolean = {
-    if ((actorNames contains src) || (actorNames contains dst))
-      return false
-    
-    return true
-  }
-  
+
   def nextActor () : String = {
+    if (actorQueue.size == 0) {
+      actorQueue = actorQueue ++ actorNames.toList
+    }
     val next = actorQueue(index)
     index = (index + 1) % actorQueue.size
     next
   }
   
-  // Notification that the system has been reset
-  def start_trace() : Unit = {
-  }
-
   
   // Figure out what is the next message to schedule.
   def schedule_new_message() : Option[(ActorCell, Envelope)] = {
@@ -75,60 +66,11 @@ class FairScheduler extends Scheduler {
     }
   }
   
-  // Get next event
-  def next_event() : Event = {
-    throw new Exception("NYI")
-  }
-
-  // Record that an event was consumed
-  def event_consumed(event: Event) = {
-  }
-  
-  def event_consumed(cell: ActorCell, envelope: Envelope) = {
-  }
-  
-  // Record that an event was produced 
-  def event_produced(event: Event) = {
-    event match {
-      case event : SpawnEvent => 
-        if (!(actorNames contains event.name)) {
-          println("Sched knows about actor " + event.name)
-          actorQueue += event.name
-          actorNames += event.name
-        }
-    }
-  }
-  
-  def event_produced(cell: ActorCell, envelope: Envelope) = {
-    val snd = envelope.sender.path.name
-    val rcv = cell.self.path.name
-    val msgs = pendingEvents.getOrElse(rcv, new Queue[(ActorCell, Envelope)])
-    
-    pendingEvents(rcv) = msgs += ((cell, envelope))
-    // Start dispatching events
-    if (!instrumenter.started.get) {
-      instrumenter.start_dispatch()
-    }
-  }
-  
-  // Called before we start processing a newly received event
-  def before_receive(cell: ActorCell) {
-    currentTime += 1
-  }
-  
-  // Called after receive is done being processed 
-  def after_receive(cell: ActorCell) {
-  }
-  
-  def notify_quiescence () {
-    println("No more messages to process " + pendingEvents)
-  }
-
   def enqueue_message(receiver: String, msg: Any) {
     throw new Exception("NYI")
   }
 
-  def shutdown() {
-    instrumenter.restart_system
+  override def notify_quiescence () {
+    println("No more messages to process " + pendingEvents)
   }
 }

--- a/src/main/scala/verification/schedulers/PeekScheduler.scala
+++ b/src/main/scala/verification/schedulers/PeekScheduler.scala
@@ -15,7 +15,6 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicBoolean
 
 
-
 /**
  * Takes a sequence of ExternalEvents as input, and plays the execution
  * forward in the same way as FairScheduler. While playing forward,
@@ -24,187 +23,71 @@ import java.util.concurrent.atomic.AtomicBoolean
  * external and internal events.
  */
 class PeekScheduler()
-    extends FairScheduler with TestOracle {
-
-  private[this] val event_orchestrator = new EventOrchestrator[ExternalEvent]()
-
-  // Handler for FailureDetector messages
-  val fd = new FDMessageOrchestrator(this)
-  event_orchestrator.set_failure_detector(fd)
-  
-  // Semaphore to wait for trace replay to be done. We initialize the
-  // semaphore to 0 rather than 1, so that the main thread blocks upon
-  // invoking acquire() until another thread release()'s it.
-  private[this] val traceSem = new Semaphore(0)
-
-  // Are we in peek or is someone using this scheduler in some strange way.
-  private[this] val peek = new AtomicBoolean(false)
-
-  // Semaphore to use when shutting down the scheduler. We initialize the
-  // semaphore to 0 rather than 1, so that the main thread blocks upon
-  // invoking acquire() until another thread release()'s it.
-  private[this] val shutdownSem = new Semaphore(0)
-
-  // A set of external messages to send. Messages sent between actors are not
-  // queued here.
-  val messagesToSend = new SynchronizedQueue[(ActorRef, Any)]()
-
-  // Are we expecting message receives
-  private[this] val started = new AtomicBoolean(false)
-
-  // Ensure that only one thread is running inside the scheduler when we are
-  // dispatching external messages to actors. (Does not guard the scheduler's instance
-  // variables.)
-  private[this] val schedSemaphore = new Semaphore(1)
+    extends FairScheduler with ExternalEventInjector with TestOracle {
 
   var test_invariant : Invariant = null
 
-  // Enqueue a message for future delivery
-  override def enqueue_message(receiver: String, msg: Any) {
-    if (actorNames contains receiver) {
-      enqueue_message(event_orchestrator.actorToActorRef(receiver), msg)
-    } else {
-      throw new IllegalArgumentException("Unknown receiver " + receiver)
-    }
-  }
-
-  private[this] def enqueue_message(actor: ActorRef, msg: Any) {
-    messagesToSend += ((actor, msg))
-  }
-
-  // Given an external event trace, see the events produced
   def peek (_trace: Seq[ExternalEvent]) : Queue[Event]  = {
-    event_orchestrator.set_trace(_trace)
-    fd.startFD(instrumenter.actorSystem)
-    // We begin by starting all actors at the beginning of time, just mark them as
-    // isolated (i.e., unreachable). Later, when we replay the `Start` event,
-    // we unisolate the actor.
-    for (t <- event_orchestrator.trace) {
-      t match {
-        case Start (prop, name) => 
-          // Just start and isolate all actors we might eventually care about [top-level actors]
-          instrumenter.actorSystem.actorOf(prop, name)
-          event_orchestrator.isolate_node(name)
-        case _ =>
-          None
-      }
-    }
-    peek.set(true)
-    // Start playing back trace
-    advanceTrace()
-    // Have this thread wait until the trace is down. This allows us to safely notify
-    // the caller.
-    traceSem.acquire
-    peek.set(false)
-    return event_orchestrator.events
-  }
-
-  // Advance the trace
-  private[this] def advanceTrace() {
-    // Make sure the actual scheduler makes no progress until we have injected all
-    // events. 
-    schedSemaphore.acquire
-    started.set(true)
-    event_orchestrator.inject_until_quiescence(enqueue_message)
-    schedSemaphore.release
-    // Since this is always called during quiescence, once we have processed all 
-    // events, let us start dispatching
-    instrumenter.start_dispatch()
+    return execute_trace(_trace)
   }
 
   override def event_produced(cell: ActorCell, envelope: Envelope) = {
     val snd = envelope.sender.path.name
     val rcv = cell.self.path.name
     val msgs = pendingEvents.getOrElse(rcv, new Queue[(ActorCell, Envelope)])
-    event_orchestrator.events += MsgSend(snd, rcv, envelope.message)
-    // Intercept any messages sent towards the failure detector
-    if (rcv == FailureDetector.fdName) {
-      fd.handle_fd_message(envelope.message, snd)
-    // Drop any messages that crosses a partition.
-    } else if (!event_orchestrator.crosses_partition(snd, rcv)) {
-      pendingEvents(rcv) = msgs += ((cell, envelope))
+    handle_event_produced(snd, rcv, envelope) match {
+      case SystemMessage() => None
+      case _ => {
+        if (!crosses_partition(snd, rcv)) {
+          pendingEvents(rcv) = msgs += ((cell, envelope))
+        }
+      }
     }
   }
 
   // Record a mapping from actor names to actor refs
   override def event_produced(event: Event) = {
     super.event_produced(event)
-    event match { 
-      case event : SpawnEvent => 
-        event_orchestrator.handle_spawn_produced(event)
-    }
+    handle_spawn_produced(event)
   }
 
   // Record that an event was consumed
   override def event_consumed(event: Event) = {
-    val spawn_event = event.asInstanceOf[SpawnEvent]
-    event_orchestrator.handle_spawn_consumed(spawn_event)
+    handle_spawn_consumed(event)
   }
-  
+
   // Record a message send event
   override def event_consumed(cell: ActorCell, envelope: Envelope) = {
-    val snd = envelope.sender.path.name
-    val rcv = cell.self.path.name
-    val msg = envelope.message
-    assert(started.get)
-    event_orchestrator.events += ChangeContext(cell.self.path.name)
-    event_orchestrator.events += MsgEvent(snd, rcv, msg)
+    handle_event_consumed(cell, envelope)
   }
 
   override def schedule_new_message() : Option[(ActorCell, Envelope)] = {
-    // Ensure that only one thread is accessing shared scheduler structures
-    schedSemaphore.acquire
-    assert(started.get)
-    
-    // Send all pending fd responses
-    fd.send_all_pending_responses()
-    // Drain message queue 
-    for ((receiver, msg) <- messagesToSend) {
-      receiver ! msg
-    }
-    messagesToSend.clear()
-
-    // Wait to make sure all messages are enqueued
-    instrumenter.await_enqueue()
-
-    // schedule_new_message is reenterant, hence release before calling.
-    schedSemaphore.release
-    super.schedule_new_message()
+    enqueue_external_messages
+    // FairScheduler gives us round-robin message dispatches.
+    return super.schedule_new_message()
   }
 
   override def notify_quiescence () {
-    assert(started.get)
-    started.set(false)
-    event_orchestrator.events += Quiescence
-    if (!event_orchestrator.trace_finished) {
-      // If waiting for quiescence.
-      advanceTrace()
-    } else {
-      if (peek.get) {
-        // Tell the calling thread we are done
-        traceSem.release
-      } else {
-        throw new RuntimeException("peek.get returned false")
-      }
-    }
+    handle_quiescence
   }
 
   // Shutdown the scheduler, this ensures that the instrumenter is returned to its
   // original pristine form, so one can change schedulers
   override def shutdown () = {
-    instrumenter.restart_system
-    shutdownSem.acquire
+    handle_shutdown
   }
   
   // Notification that the system has been reset
   override def start_trace() : Unit = {
-    shutdownSem.release
+    handle_start_trace
   }
 
-  override def before_receive(cell: ActorCell) : Unit = {
-  }
   override def after_receive(cell: ActorCell) : Unit = {
-    event_orchestrator.events += ChangeContext("scheduler")
+    handle_after_receive(cell)
+  }
+
+  override def enqueue_message(receiver: String, msg: Any) {
+    super[ExternalEventInjector].enqueue_message(receiver, msg)
   }
 
   def setInvariant(invariant: Invariant) {
@@ -212,6 +95,7 @@ class PeekScheduler()
   }
 
   def test(events: Seq[ExternalEvent]) : Boolean = {
+    Instrumenter().scheduler = this
     peek(events)
     if (test_invariant == null) {
       throw new IllegalArgumentException("Must invoke setInvariant before test()")

--- a/src/main/scala/verification/schedulers/RandomScheduler.scala
+++ b/src/main/scala/verification/schedulers/RandomScheduler.scala
@@ -1,0 +1,207 @@
+package akka.dispatch.verification
+
+import com.typesafe.config.ConfigFactory
+import akka.actor.{Actor, ActorCell, ActorRef, ActorSystem, Props}
+
+import akka.dispatch.Envelope
+
+import scala.collection.mutable.Queue
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.SynchronizedQueue
+import scala.collection.mutable.Set
+import scala.collection.mutable.HashSet
+import scala.collection.mutable.ArrayBuffer
+
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.Random
+
+// Provides O(1) insert and removeRandomElement
+class RandomizedHashSet[E] {
+  // We store a counter along with each element E to ensure uniqueness
+  var arr = new ArrayBuffer[(E,Int)]
+  // Value is index into array
+  var hash = new HashMap[(E,Int),Int]
+  val rand = new Random(System.currentTimeMillis());
+
+  def insert(value: E) = {
+    var uniqueness_counter = 0
+    while (hash.contains((value, uniqueness_counter))) {
+      uniqueness_counter += 1
+    }
+    val tuple : (E,Int) = (value,uniqueness_counter)
+    val i = arr.length
+    hash(tuple) = i
+    arr += tuple
+  }
+
+  private[this] def remove(value: (E,Int)) = {
+    // We are going to replace the cell that contains value in A with the last
+    // element in A. let d be the last element in the array A at index m. let
+    // i be H[value], the index in the array of the value to be removed. Set
+    // A[i]=d, H[d]=i, decrease the size of the array by one, and remove value
+    // from H.
+    if (!hash.contains(value)) {
+      throw new IllegalArgumentException("Value " + value + " does not exist")
+    }
+    val i = hash(value)
+    val m = arr.length - 1
+    val d = arr(m)
+    arr(i) = d
+    hash(d) = i
+    arr = arr.dropRight(1)
+    hash -= value
+  }
+
+  def removeRandomElement () : E = {
+    val random_idx = rand.nextInt(arr.length)
+    val v = arr(random_idx)
+    remove(v)
+    return v._1
+  }
+
+  def isEmpty () : Boolean = {
+    return arr.isEmpty
+  }
+}
+
+
+/**
+ * Takes a list of ExternalEvents as input, and explores random interleavings
+ * of internal messages until either a maximum number of interleavings is
+ * reached, or a given invariant is violated.
+ *
+ * Additionally records internal and external events that occur during
+ * executions that trigger violations.
+ */
+class RandomScheduler(max_interleavings: Int)
+    extends AbstractScheduler with ExternalEventInjector with TestOracle {
+
+  var test_invariant : Invariant = null
+
+  // Current set of enabled events.
+  // First element of tuple is the receiver
+  var pendingInternalEvents = new RandomizedHashSet[(ActorCell, Envelope)]
+
+  // Current set of externally injected events, to be delivered in the order
+  // they arrive.
+  var pendingExternalEvents = new Queue[(ActorCell, Envelope)]
+
+  /**
+   * Given an external event trace, randomly explore executions involving those
+   * external events.
+   *
+   * Returns a trace of the internal and external events observed if a failing execution was found,
+   * otherwise returns null if no failure was triggered within max_interleavings.
+   *
+   * Precondition: setInvariant has been invoked.
+   */
+  def explore (_trace: Seq[ExternalEvent]) : Seq[Event] = {
+    for (i <- 1 to max_interleavings) {
+      println("Trying random interleaving " + i)
+      execute_trace(_trace)
+
+      // Check the invariant at the end of the trace.
+      if (test_invariant == null) {
+        throw new IllegalArgumentException("Must invoke setInvariant before test()")
+      }
+      val passes = test_invariant(_trace)
+      if (!passes) {
+        println("Found failing execution")
+        return event_orchestrator.events
+      } else if (i != max_interleavings) {
+        // 'Tis a lesson you should heed: Try, try, try again.
+        // If at first you don't succeed: Try, try, try again
+        reset_all_state
+      }
+    }
+    // No bug found...
+    return null
+  }
+
+  override def event_produced(cell: ActorCell, envelope: Envelope) = {
+    val snd = envelope.sender.path.name
+    val rcv = cell.self.path.name
+    handle_event_produced(snd, rcv, envelope) match {
+      case InternalMessage() => {
+        if (!crosses_partition(snd, rcv)) {
+          pendingInternalEvents.insert((cell, envelope))
+        }
+      }
+      case ExternalMessage() => {
+        pendingExternalEvents += ((cell, envelope))
+      }
+      case SystemMessage() => None
+    }
+  }
+
+  // Record a mapping from actor names to actor refs
+  override def event_produced(event: Event) = {
+    super.event_produced(event)
+    handle_spawn_produced(event)
+  }
+
+  // Record that an event was consumed
+  override def event_consumed(event: Event) = {
+    handle_spawn_consumed(event)
+  }
+
+  // Record a message send event
+  override def event_consumed(cell: ActorCell, envelope: Envelope) = {
+    handle_event_consumed(cell, envelope)
+  }
+
+  override def schedule_new_message() : Option[(ActorCell, Envelope)] = {
+    enqueue_external_messages
+    // Always prioritize external events.
+    if (!pendingExternalEvents.isEmpty) {
+      return Some(pendingExternalEvents.dequeue())
+    }
+
+    // Do we have some pending events
+    if (pendingInternalEvents.isEmpty) {
+      return None
+    }
+    return Some(pendingInternalEvents.removeRandomElement())
+  }
+
+  override def notify_quiescence () {
+    handle_quiescence
+  }
+
+  // Shutdown the scheduler, this ensures that the instrumenter is returned to its
+  // original pristine form, so one can change schedulers
+  override def shutdown () = {
+    handle_shutdown
+  }
+
+  // Notification that the system has been reset
+  override def start_trace() : Unit = {
+    handle_start_trace
+  }
+
+  override def after_receive(cell: ActorCell) : Unit = {
+    handle_after_receive(cell)
+  }
+
+  def setInvariant(invariant: Invariant) {
+    test_invariant = invariant
+  }
+
+  def reset_all_state () {
+    pendingInternalEvents = new RandomizedHashSet[(ActorCell, Envelope)]
+    pendingExternalEvents = new Queue[(ActorCell, Envelope)]
+    actorNames = new HashSet[String]
+    currentTime = 0
+    // TODO(cs): also reset Instrumenter()'s state?
+    reset_state
+  }
+
+  def test(events: Seq[ExternalEvent]) : Boolean = {
+    Instrumenter().scheduler = this
+    val execution = explore(events)
+    reset_all_state
+    // test passes if we were unable to find a failure.
+    return execution == null
+  }
+}


### PR DESCRIPTION
There was lots of redundancy between PeekScheduler and RandomScheduler. I
pulled this redundancy out into a mix-in trait: ExternalEventInjector.

There was also redundancy between PeekScheduler, FairScheduler, and
RandomScheduler. I pulled this out into an abstract superclass:
AbstractScheduler. It basically just tracks the names of actors in the system.

Slight change to the FailureDetector interface: take an anonymous function
rather than an entire scheduler.