### PR TITLE
Check invariants mid-execution in RandomScheduler

### DIFF
--- a/src/main/scala/verification/fuzzing/Fuzzer.scala
+++ b/src/main/scala/verification/fuzzing/Fuzzer.scala
@@ -6,7 +6,7 @@ import scala.util.Random
 
 // Needs to be implemented by the application.
 trait MessageGenerator {
-  def generateMessage() : Any
+  def generateMessage(aliveActors: RandomizedHashSet[String]) : Send
 }
 
 object StableClasses {
@@ -106,8 +106,8 @@ class Fuzzer(num_events: Integer,
             return Some(Kill(nextVictim))
 
           case StableClasses.ClassOfSend =>
-            val message = message_gen.generateMessage()
-            return Some(Send(currentlyAlive.getRandomElement(), () => message))
+            val send = message_gen.generateMessage(currentlyAlive)
+            return Some(send)
 
           case StableClasses.ClassOfWaitTimers =>
             return Some(WaitTimers(1))
@@ -131,7 +131,7 @@ class Fuzzer(num_events: Integer,
             return Some(UnPartition(pair._1, pair._2))
 
           case StableClasses.ClassOfContinue =>
-            return Some(Continue(rand.nextInt(maxContinueSteps)))
+            return Some(Continue(rand.nextInt(maxContinueSteps) + 1))
         }
     }
     throw new IllegalStateException("Shouldn't get here")

--- a/src/main/scala/verification/minification/Minimizer.scala
+++ b/src/main/scala/verification/minification/Minimizer.scala
@@ -1,5 +1,5 @@
 package akka.dispatch.verification
 
 trait Minimizer {
-  def minimize(events: Seq[ExternalEvent]) : Seq[ExternalEvent]
+  def minimize(events: Seq[ExternalEvent], violation_fingerprint: ViolationFingerprint) : Seq[ExternalEvent]
 }

--- a/src/main/scala/verification/minification/OneAtATime.scala
+++ b/src/main/scala/verification/minification/OneAtATime.scala
@@ -4,10 +4,10 @@ import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.HashSet
 
 class LeftToRightRemoval (oracle: TestOracle) extends Minimizer {
-  def minimize(events: Seq[ExternalEvent]) : Seq[ExternalEvent] = {
+  def minimize(events: Seq[ExternalEvent], violation_fingerprint: ViolationFingerprint) : Seq[ExternalEvent] = {
     // First check if the initial trace violates the exception
     println("Checking if unmodified trace triggers violation...")
-    if (oracle.test(events)) {
+    if (oracle.test(events, violation_fingerprint)) {
       throw new IllegalArgumentException("Unmodified trace does not trigger violation")
     }
 
@@ -22,7 +22,7 @@ class LeftToRightRemoval (oracle: TestOracle) extends Minimizer {
       tested_events += event
       val new_dag = dag.remove_events(List(event))
 
-      if (oracle.test(new_dag.get_all_events)) {
+      if (oracle.test(new_dag.get_all_events, violation_fingerprint)) {
         println("passes")
         // Move on to the next event to test
         events_to_test = events_to_test.slice(1, events_to_test.length)

--- a/src/main/scala/verification/minification/TestOracle.scala
+++ b/src/main/scala/verification/minification/TestOracle.scala
@@ -2,22 +2,33 @@ package akka.dispatch.verification
 
 import scala.collection.mutable.HashMap
 
+/**
+ * User-defined fingerprint for uniquely describing how one or more safety
+ * violations manifests.
+ */
+trait ViolationFingerprint {
+  def matches(other: ViolationFingerprint) : Boolean
+}
+
 trait TestOracle {
-  // An predicate that returns true if the safety condition is not violated,
-  // i.e. the execution is correct. Otherwise, returns false.
-  type Invariant = (Seq[ExternalEvent], HashMap[String,CheckpointReply]) => Boolean
+  // An predicate that returns None if the safety condition is not violated,
+  // i.e. the execution is correct. Otherwise, returns a
+  // `fingerprint` that identifies how the safety violation manifests itself..
+  type Invariant = (Seq[ExternalEvent], HashMap[String,CheckpointReply]) => Option[ViolationFingerprint]
 
   def setInvariant(invariant: Invariant)
 
   /**
    * Returns false if there exists any execution containing the given external
-   * events that causes the invariant to return false. Otherwise, returns true.
+   * events that causes the given invariant violation to reappear.
+   * Otherwise, returns true.
    *
    * At the end of the invocation, it is the responsibility of the TestOracle
    * to ensure that the ActorSystem is returned to a clean initial state.
    * Throws an IllegalArgumentException if setInvariant has not been invoked.
    */
-  def test(events: Seq[ExternalEvent]) : Boolean
+  def test(events: Seq[ExternalEvent],
+           violation_fingerprint: ViolationFingerprint) : Boolean
 }
 
 object StatelessTestOracle {
@@ -39,7 +50,7 @@ class StatelessTestOracle(oracle_ctor: StatelessTestOracle.OracleConstructor) ex
     invariant = inv
   }
 
-  def test(events: Seq[ExternalEvent]) : Boolean = {
+  def test(events: Seq[ExternalEvent], violation_fingerprint: ViolationFingerprint) : Boolean = {
     val oracle = oracle_ctor()
     try {
       Instrumenter().scheduler = oracle.asInstanceOf[Scheduler]
@@ -47,7 +58,7 @@ class StatelessTestOracle(oracle_ctor: StatelessTestOracle.OracleConstructor) ex
       case e: Exception => println("oracle not a scheduler?")
     }
     oracle.setInvariant(invariant)
-    val result = oracle.test(events)
+    val result = oracle.test(events, violation_fingerprint)
     Instrumenter().restart_system
     return result
   }

--- a/src/main/scala/verification/schedulers/EventOrchestrator.scala
+++ b/src/main/scala/verification/schedulers/EventOrchestrator.scala
@@ -95,6 +95,7 @@ class EventOrchestrator[E] {
   def inject_until_quiescence(enqueue_message: EnqueueMessage) = {
     var loop = true
     while (loop && !trace_finished) {
+      println("Injecting " + current_event)
       current_event.asInstanceOf[ExternalEvent] match {
         case Start (_, name) =>
           trigger_start(name)

--- a/src/main/scala/verification/schedulers/EventOrchestrator.scala
+++ b/src/main/scala/verification/schedulers/EventOrchestrator.scala
@@ -95,7 +95,7 @@ class EventOrchestrator[E] {
   def inject_until_quiescence(enqueue_message: EnqueueMessage) = {
     var loop = true
     while (loop && !trace_finished) {
-      println("Injecting " + current_event)
+      println("Injecting " + traceIdx + "/" + trace.length + " " + current_event)
       current_event.asInstanceOf[ExternalEvent] match {
         case Start (_, name) =>
           trigger_start(name)

--- a/src/main/scala/verification/schedulers/PeekScheduler.scala
+++ b/src/main/scala/verification/schedulers/PeekScheduler.scala
@@ -52,7 +52,7 @@ class PeekScheduler(enableFailureDetector: Boolean)
     val msgs = pendingEvents.getOrElse(rcv, new Queue[(ActorCell, Envelope)])
     handle_event_produced(snd, rcv, envelope) match {
       case SystemMessage => None
-      case CheckpointMessage => None
+      case CheckpointReplyMessage => None
       case _ => {
         if (!crosses_partition(snd, rcv)) {
           pendingEvents(rcv) = msgs += ((cell, envelope))


### PR DESCRIPTION
Also: Invariants now return a `fingerprint` of the violation rather than true/false.